### PR TITLE
Добавлены Docker Compose профили для опциональных сервисов

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ docker compose -p bitrixdock up -d
 Посмотрите все прослушиваемые порты, должны быть 80, 11211, 9000 `netstat -plnt`.
 Откройте IP машины в браузере.
 
+### Запуск с опциональными сервисами
+В bitrixdock есть профили для запуска опциональных сервисов:
+- `admin` - для запуска сервиса Adminer (веб-интерфейс для управления базами данных)
+- `push` - для запуска push-сервера Битрикс и Redis
+
+Для запуска с профилями:
+```shell
+docker compose -p bitrixdock --profile admin --profile push up -d
+```
+
 ### Остановка
 ```shell
 docker compose -p bitrixdock stop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,11 +14,15 @@ services:
         networks:
             - bitrixdock
         restart: unless-stopped
+        extra_hosts:
+            - "bitrix.local:172.18.0.9"
 
     web_server:
         build: ./${WEB_SERVER_TYPE}
         depends_on:
             - source
+            - push-server-sub
+            - push-server-pub
         volumes_from:
             - source
         ports:
@@ -27,7 +31,8 @@ services:
         links:
             - php
         networks:
-            - bitrixdock
+            bitrixdock:
+                ipv4_address: 172.18.0.9
         environment:
             TZ: Europe/Moscow
         stdin_open: true
@@ -82,6 +87,37 @@ services:
         networks:
             - bitrixdock
 
+    push-server-sub:
+        image: ikarpovich/bitrix-push-server
+        networks:
+            - bitrixdock
+        environment:
+            - REDIS_HOST=redis
+            - LISTEN_HOSTNAME=0.0.0.0
+            - LISTEN_PORT=8010
+            - SECURITY_KEY=testtesttest
+            - MODE=sub
+        depends_on:
+            - redis
+
+    push-server-pub:
+        image: ikarpovich/bitrix-push-server
+        networks:
+            - bitrixdock
+        environment:
+            - REDIS_HOST=redis
+            - LISTEN_HOSTNAME=0.0.0.0
+            - LISTEN_PORT=8010
+            - SECURITY_KEY=testtesttest
+            - MODE=pub
+        depends_on:
+            - redis
+
+    redis:
+        image: redis
+        networks:
+            - bitrixdock
+
     source:
         image: alpine:latest
         volumes:
@@ -93,6 +129,7 @@ services:
             - cache:/var/lib/memcached
             - ${SITE_PATH}:/var/www/bitrix
             - /etc/localtime:/etc/localtime/:ro
+            - ./nginx/conf/default.conf:/etc/nginx/conf.d/default.conf
         networks:
             - bitrixdock
 
@@ -104,3 +141,6 @@ volumes:
 
 networks:
     bitrixdock:
+        ipam:
+            config:
+                - subnet: 172.18.0.0/24

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,6 @@ services:
             - cache:/var/lib/memcached
             - ${SITE_PATH}:/var/www/bitrix
             - /etc/localtime:/etc/localtime/:ro
-            - ./nginx/conf/default.conf:/etc/nginx/conf.d/default.conf
         networks:
             - bitrixdock
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,6 @@ services:
         build: ./${WEB_SERVER_TYPE}
         depends_on:
             - source
-            - push-server-sub
-            - push-server-pub
         volumes_from:
             - source
         ports:
@@ -86,6 +84,8 @@ services:
         tty: true
         networks:
             - bitrixdock
+        profiles:
+            - admin
 
     push-server-sub:
         image: ikarpovich/bitrix-push-server
@@ -99,6 +99,8 @@ services:
             - MODE=sub
         depends_on:
             - redis
+        profiles:
+            - push
 
     push-server-pub:
         image: ikarpovich/bitrix-push-server
@@ -112,11 +114,15 @@ services:
             - MODE=pub
         depends_on:
             - redis
+        profiles:
+            - push
 
     redis:
         image: redis
         networks:
             - bitrixdock
+        profiles:
+            - push
 
     source:
         image: alpine:latest

--- a/nginx/conf/default.conf
+++ b/nginx/conf/default.conf
@@ -2,7 +2,7 @@ server {
     listen 80 deferred reuseport default;
     listen [::]:80 deferred reuseport default;
 
-    server_name bitrix;
+    server_name bitrix.local bitrix;
     charset utf-8;
     root /var/www/bitrix;
     index index.php index.html bitrixsetup.php;
@@ -12,10 +12,6 @@ server {
 
     # bitrix recommendation, respect server's mime-type and don't try to guess it
     add_header X-Content-Type-Options nosniff;
-
-    if (!-e $request_filename) {
-       rewrite  ^(.*)$  /bitrix/urlrewrite.php last;
-    }
 
     # remove multiple slashes
     # duplicated slashes sometimes will work and won't be rewritten, fixing it in this configuration is tricky
@@ -98,6 +94,39 @@ server {
         # make SERVER_NAME behave same as HTTP_HOST
         fastcgi_param SERVER_NAME $host;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    }
+
+    location /bitrix/pub/ {
+        # IM doesn't wait
+        proxy_ignore_client_abort on;
+        proxy_pass http://push-server-pub:8010;
+    }
+
+    location ~* ^/bitrix/subws/ {
+        access_log off;
+        proxy_pass http://push-server-sub:8010;
+        # http://blog.martinfjordvald.com/2013/02/websockets-in-nginx/
+        # 12h+0.5
+        proxy_max_temp_file_size 0;
+        proxy_read_timeout  43800;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $replace_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+
+    location ~* ^/bitrix/sub/ {
+        access_log off;
+        rewrite ^/bitrix/sub/(.*)$ /bitrix/subws/$1 break;
+        proxy_pass http://push-server-sub:8010;
+        proxy_max_temp_file_size 0;
+        proxy_read_timeout  43800;
+    }
+
+    location ~* ^/bitrix/rest/ {
+        access_log off;
+        proxy_pass http://push-server-pub:8010;
+        proxy_max_temp_file_size 0;
+        proxy_read_timeout  43800;
     }
 
     error_page 404 /404.html;

--- a/nginx/conf/nginx.conf
+++ b/nginx/conf/nginx.conf
@@ -57,6 +57,16 @@ http {
 
     include /etc/nginx/conf.d/*.conf;
     include /etc/nginx/sites-available/*;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' 'close';
+    }
+
+    map $http_upgrade  $replace_upgrade {
+        default $http_upgrade;
+        '' "websocket";
+    }
 }
 
 daemon off;


### PR DESCRIPTION
## Краткое описание
- Добавлен профиль "admin" для сервиса Adminer
- Добавлен профиль "push" для push-серверов и Redis
- Удалена зависимость web_server от push-серверов, которые не запускаются по умолчанию
- Обновлена документация с указанием способа запуска опциональных сервисов

## Детали изменений
В соответствии с комментариями в https://github.com/bitrixdock/bitrixdock/pull/241, сервисы push-server и adminer сделаны опциональными с использованием Docker Compose профилей. Теперь они не будут запускаться по умолчанию, а только при явном указании профиля.

🤖 Generated with [Claude Code](https://claude.ai/code)